### PR TITLE
XOL-5226 Handle new Stripe API variables for v2019-12-03

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: php
 
 php:
-  - 5.3
-  - 5.4
-  - 5.5
   - 5.6
+  - 7.0
+  - 7.1
+  - 7.2
 
 before_script:
   - composer install -n --dev --prefer-source

--- a/src/Message/AuthorizeRequest.php
+++ b/src/Message/AuthorizeRequest.php
@@ -166,6 +166,16 @@ class AuthorizeRequest extends AbstractRequest
         return (int) round($this->getApplicationFee() * pow(10, $this->getCurrencyDecimalPlaces()));
     }
 
+    /**
+     * @param string $value
+     *
+     * @return AbstractRequest provides a fluent interface.
+     */
+    public function setApplicationFee($value)
+    {
+        return $this->setParameter('applicationFee', $value);
+    }
+
     public function getStatementDescriptor()
     {
         return $this->getParameter('statementDescriptor');

--- a/src/Message/AuthorizeRequest.php
+++ b/src/Message/AuthorizeRequest.php
@@ -77,14 +77,6 @@ class AuthorizeRequest extends AbstractRequest
     /**
      * @return mixed
      */
-    public function getTransferData()
-    {
-        return $this->getParameter('transferData');
-    }
-
-    /**
-     * @return mixed
-     */
     public function getDestination()
     {
         return $this->getParameter('destination');
@@ -98,16 +90,6 @@ class AuthorizeRequest extends AbstractRequest
     public function setDestination($value)
     {
         return $this->setParameter('destination', $value);
-    }
-
-    /**
-     * @param string $value
-     *
-     * @return AbstractRequest provides a fluent interface.
-     */
-    public function setTransferData($value)
-    {
-        return $this->setParameter('transferData', $value);
     }
 
     /**
@@ -184,42 +166,6 @@ class AuthorizeRequest extends AbstractRequest
         return (int) round($this->getApplicationFee() * pow(10, $this->getCurrencyDecimalPlaces()));
     }
 
-    /**
-     * @param string $value
-     *
-     * @return AbstractRequest provides a fluent interface.
-     */
-    public function setApplicationFee($value)
-    {
-        return $this->setParameter('applicationFee', $value);
-    }
-
-    /**
-     * @return float
-     */
-    public function getApplicationFeeAmount()
-    {
-        return $this->getParameter('applicationFeeAmount');
-    }
-
-    /**
-     * @return int
-     */
-    public function getApplicationFeeAmountInteger()
-    {
-        return (int) round($this->getApplicationFeeAmount() * pow(10, $this->getCurrencyDecimalPlaces()));
-    }
-
-    /**
-     * @param string $value
-     *
-     * @return AbstractRequest provides a fluent interface.
-     */
-    public function setApplicationFeeAmount($value)
-    {
-        return $this->setParameter('applicationFeeAmount', $value);
-    }
-
     public function getStatementDescriptor()
     {
         return $this->getParameter('statementDescriptor');
@@ -230,18 +176,6 @@ class AuthorizeRequest extends AbstractRequest
         $value = str_replace(array('<', '>', '"', '\''), '', $value);
 
         return $this->setParameter('statementDescriptor', $value);
-    }
-
-    public function getStatementDescriptorSuffix()
-    {
-        return $this->getParameter('statementDescriptorSuffix');
-    }
-
-    public function setStatementDescriptorSuffix($value)
-    {
-        $value = str_replace(array('<', '>', '"', '\''), '', $value);
-
-        return $this->setParameter('statementDescriptorSuffix', $value);
     }
 
     /**
@@ -277,29 +211,21 @@ class AuthorizeRequest extends AbstractRequest
 
         $apiVersion = $this->getApiVersion();
         if (is_null($apiVersion) || (!is_null($apiVersion) && $apiVersion >= self::API_VERSION_STATEMENT_DESCRIPTOR)) {
-            if ($this->getStatementDescriptorSuffix()) {
-                $data['statement_descriptor_suffix'] = $this->getStatementDescriptorSuffix();
-            } else {
-                $data['statement_descriptor'] = $this->getStatementDescriptor();
-            }
+            $data['statement_descriptor_suffix'] = $this->getStatementDescriptor();
         } else {
             $data['statement_description'] = $this->getStatementDescriptor();
         }
 
-        if ($this->getTransferData()) {
-            $data['transfer_data'] = $this->getTransferData();
-        } else if ($this->getDestination()) {
-            $data['destination'] = $this->getDestination();
+        if ($this->getDestination()) {
+            $data['transfer_data'] = ['destination' => $this->getDestination()];
         }
 
         if ($this->getOnBehalfOf()) {
             $data['on_behalf_of'] = $this->getOnBehalfOf();
         }
 
-        if ($this->getApplicationFeeAmount()) {
-            $data['application_fee_amount'] = $this->getApplicationFeeAmountInteger();
-        }  else if ($this->getApplicationFee()) {
-            $data['application_fee'] = $this->getApplicationFeeInteger();
+        if ($this->getApplicationFee()) {
+            $data['application_fee_amount'] = $this->getApplicationFeeInteger();
         }
 
         if ($this->getTransferGroup()) {

--- a/src/Message/AuthorizeRequest.php
+++ b/src/Message/AuthorizeRequest.php
@@ -232,6 +232,18 @@ class AuthorizeRequest extends AbstractRequest
         return $this->setParameter('statementDescriptor', $value);
     }
 
+    public function getStatementDescriptorSuffix()
+    {
+        return $this->getParameter('statementDescriptorSuffix');
+    }
+
+    public function setStatementDescriptorSuffix($value)
+    {
+        $value = str_replace(array('<', '>', '"', '\''), '', $value);
+
+        return $this->setParameter('statementDescriptorSuffix', $value);
+    }
+
     /**
      * @return mixed
      */
@@ -265,7 +277,11 @@ class AuthorizeRequest extends AbstractRequest
 
         $apiVersion = $this->getApiVersion();
         if (is_null($apiVersion) || (!is_null($apiVersion) && $apiVersion >= self::API_VERSION_STATEMENT_DESCRIPTOR)) {
-            $data['statement_descriptor'] = $this->getStatementDescriptor();
+            if ($this->getStatementDescriptorSuffix()) {
+                $data['statement_descriptor_suffix'] = $this->getStatementDescriptorSuffix();
+            } else {
+                $data['statement_descriptor'] = $this->getStatementDescriptor();
+            }
         } else {
             $data['statement_description'] = $this->getStatementDescriptor();
         }

--- a/src/Message/AuthorizeRequest.php
+++ b/src/Message/AuthorizeRequest.php
@@ -77,6 +77,14 @@ class AuthorizeRequest extends AbstractRequest
     /**
      * @return mixed
      */
+    public function getTransferData()
+    {
+        return $this->getParameter('transferData');
+    }
+
+    /**
+     * @return mixed
+     */
     public function getDestination()
     {
         return $this->getParameter('destination');
@@ -90,6 +98,16 @@ class AuthorizeRequest extends AbstractRequest
     public function setDestination($value)
     {
         return $this->setParameter('destination', $value);
+    }
+
+    /**
+     * @param string $value
+     *
+     * @return AbstractRequest provides a fluent interface.
+     */
+    public function setTransferData($value)
+    {
+        return $this->setParameter('transferData', $value);
     }
 
     /**
@@ -176,6 +194,32 @@ class AuthorizeRequest extends AbstractRequest
         return $this->setParameter('applicationFee', $value);
     }
 
+    /**
+     * @return float
+     */
+    public function getApplicationFeeAmount()
+    {
+        return $this->getParameter('applicationFeeAmount');
+    }
+
+    /**
+     * @return int
+     */
+    public function getApplicationFeeAmountInteger()
+    {
+        return (int) round($this->getApplicationFeeAmount() * pow(10, $this->getCurrencyDecimalPlaces()));
+    }
+
+    /**
+     * @param string $value
+     *
+     * @return AbstractRequest provides a fluent interface.
+     */
+    public function setApplicationFeeAmount($value)
+    {
+        return $this->setParameter('applicationFeeAmount', $value);
+    }
+
     public function getStatementDescriptor()
     {
         return $this->getParameter('statementDescriptor');
@@ -226,7 +270,9 @@ class AuthorizeRequest extends AbstractRequest
             $data['statement_description'] = $this->getStatementDescriptor();
         }
 
-        if ($this->getDestination()) {
+        if ($this->getTransferData()) {
+            $data['transfer_data'] = $this->getTransferData();
+        } else if ($this->getDestination()) {
             $data['destination'] = $this->getDestination();
         }
 
@@ -234,7 +280,9 @@ class AuthorizeRequest extends AbstractRequest
             $data['on_behalf_of'] = $this->getOnBehalfOf();
         }
 
-        if ($this->getApplicationFee()) {
+        if ($this->getApplicationFeeAmount()) {
+            $data['application_fee_amount'] = $this->getApplicationFeeAmountInteger();
+        }  else if ($this->getApplicationFee()) {
             $data['application_fee'] = $this->getApplicationFeeInteger();
         }
 

--- a/tests/Message/AuthorizeRequestTest.php
+++ b/tests/Message/AuthorizeRequestTest.php
@@ -32,7 +32,7 @@ class AuthorizeRequestTest extends TestCase
         $this->assertSame('Order #42', $data['description']);
         $this->assertSame('false', $data['capture']);
         $this->assertSame(array('foo' => 'bar'), $data['metadata']);
-        $this->assertSame(100, $data['application_fee']);
+        $this->assertSame(100, $data['application_fee_amount']);
     }
 
     /**
@@ -69,7 +69,7 @@ class AuthorizeRequestTest extends TestCase
         $this->request->setStatementDescriptor('OMNIPAY');
         $data = $this->request->getData();
 
-        $this->assertSame('OMNIPAY', $data['statement_descriptor']);
+        $this->assertSame('OMNIPAY', $data['statement_descriptor_suffix']);
     }
 
     public function testDataWithSourceAndDestination()
@@ -79,7 +79,7 @@ class AuthorizeRequestTest extends TestCase
         $data = $this->request->getData();
 
         $this->assertSame('abc', $data['source']);
-        $this->assertSame('xyz', $data['destination']);
+        $this->assertSame('xyz', $data['transfer_data']['destination']);
     }
 
     public function testDataWithToken()

--- a/tests/Message/PurchaseRequestTest.php
+++ b/tests/Message/PurchaseRequestTest.php
@@ -45,7 +45,7 @@ class PurchaseRequestTest extends TestCase
                 'object' => 'card',
                 'email' => null
             ),
-            'statement_descriptor' => 'FOO',
+            'statement_descriptor_suffix' => 'FOO',
             'description' => null,
             'capture' => 'true',
             'metadata' => null
@@ -100,7 +100,7 @@ class PurchaseRequestTest extends TestCase
                 'object' => 'card',
                 'email' => null
             ),
-            'statement_descriptor' => 'BOBS ANTIQUES',
+            'statement_descriptor_suffix' => 'BOBS ANTIQUES',
             'description' => null,
             'capture' => 'true',
             'metadata' => null,
@@ -178,7 +178,7 @@ class PurchaseRequestTest extends TestCase
                 'object' => 'card',
                 'email' => null
             ),
-            'statement_descriptor' => 'BOBS ANTIQUES',
+            'statement_descriptor_suffix' => 'BOBS ANTIQUES',
             'description' => null,
             'capture' => 'true',
             'metadata' => null
@@ -195,7 +195,7 @@ class PurchaseRequestTest extends TestCase
 
         $data = $this->request->getData();
 
-        $this->assertFalse(isset($data['statement_descriptor']), 'statement_descriptor should not be used for older version of the API');
+        $this->assertFalse(isset($data['statement_descriptor_suffix']), 'statement_descriptor_suffix should not be used for older version of the API');
         $this->assertNotNull($data['statement_description'], 'statement_description should be used for this api version');
         $this->assertEquals('FOO', $data['statement_description']);
     }


### PR DESCRIPTION
This PR is created from v2.6.3 because master uses Omnipay 3.0 which if integrated will introduce additional dev and QA overhead to test